### PR TITLE
Fix `_config.yml` to use `remote_theme:` instead `theme:`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,7 +30,7 @@ twitter_username: jekyllrb
 github_username:  jekyll
 
 # Build settings
-theme: monochrome
+remote_theme: dyutibarma/monochrome
 plugins:
   - jekyll-feed
 


### PR DESCRIPTION
In order to use remote schemes outside of supported list
provided by GitHub, `_config.yml` must include `remote_theme:`
key instead of just `theme`.